### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "stdout-stream",
   "description": "Non-blocking stdout stream",
   "version": "1.4.0",
+  "license": "MIT",
   "repository": "mafintosh/stdout-stream",
   "devDependencies": {
     "tape": "~2.12.3"


### PR DESCRIPTION
This project includes the license text in the LICENSE file, but it doesn't indicate which license it uses in the package.json metadata, which doesn't play nicely with some tooling.