### PR TITLE
Update to readable-stream ^4.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var Writable = require('readable-stream/writable');
+var { Writable } = require('readable-stream');
 
 var exists = function(path) {
 	try {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.4.1",
   "repository": "mafintosh/stdout-stream",
   "devDependencies": {
-    "tape": "~5.5.3"
+    "tape": "^5.5.3"
   },
   "scripts": {
     "test": "tape test/index.js"

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "version": "1.4.1",
   "repository": "mafintosh/stdout-stream",
   "devDependencies": {
-    "tape": "~2.12.3"
+    "tape": "~5.5.3"
   },
   "scripts": {
     "test": "tape test/index.js"
   },
   "dependencies": {
-    "readable-stream": "^2.0.1"
+    "readable-stream": "^4.1.0"
   },
   "license": "MIT"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ tape('end stdout', function(t) {
 		buf.push(data);
 	});
 	ch.stdout.on('end', function() {
-		t.same(Buffer.concat(buf).toString(), 'stdout');
+		t.same(buf.join(), 'stdout');
 		t.ok(!processOnExit);
 		stdoutOnEnd = true;
 	});


### PR DESCRIPTION
Hey, thanks for the contribution opportunity on this!

I got tests passing locally but I'm unsure on a couple of things:

1. Is the fact that the `data` object emitted by the `data` event a string now instead of a `Buffer` a breaking change? Looking at the nodejs docs for stream it looks like back to v8 it could be a `<Buffer | string | any>` so I'm unsure if I should do something to change it back to `Buffer` in the one test case or if flipping it from Buffer.concat to Array.prototype.join is good enough.
2.  I was unsure if you wanted me to change the version in the package.json file or if you did that yourself.

Thanks again!

Fixes: #5 